### PR TITLE
Add 'tel:' link to About

### DIFF
--- a/layouts/partials/sections/about.html
+++ b/layouts/partials/sections/about.html
@@ -30,6 +30,8 @@
           <li>
             {{ if eq .name "Email" }}
               <a href="mailto:{{ .url }}" target="/"><i class="{{ .icon }}"></i></a>
+            {{ else if eq .name "Phone" }}
+              <a href="tel:{{ .url }}" target="/"><i class="{{ .icon }}"></i></a>
             {{ else }}
               <a href="{{ .url }}" target="/"><i class="{{ .icon }}"></i></a>
             {{ end }}


### PR DESCRIPTION
Just like a `mailto:` link sends an email, a `tel:` link allows a user to make a phone call directly from the page.

### Issue
No Issue

### Description

Adds a direct-dial link to the about page allowing visitors to directly make a phone call from a webpage

### Test Evidence
![Screen Shot 2021-03-11 at 8 41 10 AM](https://user-images.githubusercontent.com/2071898/110796126-9b9c5400-8245-11eb-9ac3-ad6d3fcad8e0.png)
![Screen Shot 2021-03-11 at 8 40 54 AM](https://user-images.githubusercontent.com/2071898/110796127-9c34ea80-8245-11eb-8367-3555280dfbf0.png)
